### PR TITLE
Add support to get the next/last unit time

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,7 @@ mod tests {
                 let output = format_chrono(&_date, dialect);
                 let expected: &str = $expect;
                 if output != expected {
-                    panic!("unexpected output attempting to format [chrono] {input:?}.\nexpected: {expected:?}\n  parsed: {_date:?}");
+                    panic!("unexpected output attempting to format [chrono] {input:?}.\nexpected: {expected:?}\n  parsed: {_date:?} [{output:?}]");
                 }
             }
             #[cfg(feature = "time")]
@@ -244,7 +244,7 @@ mod tests {
                 let output = format_time(&_date, dialect);
                 let expected: &str = $expect;
                 if output != expected {
-                    panic!("unexpected output attempting to format [time] {input:?}.\nexpected: {expected:?}\n  parsed: {_date:?}");
+                    panic!("unexpected output attempting to format [time] {input:?}.\nexpected: {expected:?}\n  parsed: {_date:?} [{output:?}]");
                 }
             }
         };
@@ -267,6 +267,10 @@ mod tests {
         assert_date_string!("next mon", Us, "2018-03-26T00:00:00+02:00");
         // but otherwise it means the day in the next week..
         assert_date_string!("next mon", Uk, "2018-04-02T00:00:00+02:00");
+
+        assert_date_string!("last year", Uk, "2017-03-21T00:00:00+02:00");
+        assert_date_string!("this year", Uk, "2018-03-21T00:00:00+02:00");
+        assert_date_string!("next year", Uk, "2019-03-21T00:00:00+02:00");
 
         assert_date_string!("last fri 9.30", Uk, "2018-03-16T09:30:00+02:00");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,7 +355,7 @@ mod tests {
         assert_duration_err!("tuesday", DateError::UnexpectedDate);
         assert_duration_err!(
             "bananas",
-            DateError::ExpectedToken("week day or month name", 0..7)
+            DateError::ExpectedToken("unsupported identifier", 0..7)
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,11 @@ mod tests {
             };
         }
 
+        assert_duration!("1 seconds", Interval::Seconds(1));
+        assert_duration!("24 seconds", Interval::Seconds(24));
+        assert_duration!("34 s", Interval::Seconds(34));
+        assert_duration!("34 sec", Interval::Seconds(34));
+
         assert_duration!("6h", Interval::Seconds(6 * 3600));
         assert_duration!("4 hours ago", Interval::Seconds(-4 * 3600));
         assert_duration!("5 min", Interval::Seconds(5 * 60));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -200,6 +200,12 @@ impl<'a> DateParser<'a> {
                     // we'll try parse the time component later
                     Ok(Some(DateSpec::FromName(ByName::WeekDay(weekday), direct)))
                 } else if let Some(interval) = time_unit(self.s.slice()) {
+                    let interval = match direct {
+                        Direction::Last => interval * -1,
+                        #[allow(clippy::erasing_op)]
+                        Direction::Here => interval * 0,
+                        Direction::Next => interval,
+                    };
                     Ok(Some(DateSpec::Relative(interval)))
                 } else {
                     Err(DateError::ExpectedToken(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -199,9 +199,11 @@ impl<'a> DateParser<'a> {
                     // {weekday} [{time}]
                     // we'll try parse the time component later
                     Ok(Some(DateSpec::FromName(ByName::WeekDay(weekday), direct)))
+                } else if let Some(interval) = time_unit(self.s.slice()) {
+                    Ok(Some(DateSpec::Relative(interval)))
                 } else {
                     Err(DateError::ExpectedToken(
-                        "week day or month name",
+                        "unsupported identifier",
                         self.s.span(),
                     ))
                 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -245,19 +245,14 @@ pub struct DateTimeSpec {
 
 // same as chrono's 'count days from monday' convention
 pub fn week_day(s: &str) -> Option<u8> {
-    let mut s = match s.as_bytes() {
-        [a, b, c, ..] => [*a, *b, *c],
-        _ => return None,
-    };
-    s.make_ascii_lowercase();
-    match &s {
-        b"sun" => Some(6),
-        b"mon" => Some(0),
-        b"tue" => Some(1),
-        b"wed" => Some(2),
-        b"thu" => Some(3),
-        b"fri" => Some(4),
-        b"sat" => Some(5),
+    match s.to_ascii_lowercase().as_str() {
+        "sun" | "sunday" => Some(6),
+        "mon" | "monday" => Some(0),
+        "tue" | "tuesday" => Some(1),
+        "wed" | "wednesday" => Some(2),
+        "thu" | "thursday" => Some(3),
+        "fri" | "friday" => Some(4),
+        "sat" | "saturday" => Some(5),
         _ => None,
     }
 }
@@ -286,15 +281,14 @@ pub fn month_name(s: &str) -> Option<u32> {
 }
 
 pub fn time_unit(s: &str) -> Option<Interval> {
-    let s = if s.len() > 3 { &s[..3] } else { s };
-    match s.as_bytes() {
-        b"sec" | b"s" => Some(Interval::Seconds(1)),
-        b"min" | b"m" => Some(Interval::Seconds(60)),
-        b"hou" | b"h" => Some(Interval::Seconds(60 * 60)),
-        b"day" | b"d" => Some(Interval::Days(1)),
-        b"wee" | b"w" => Some(Interval::Days(7)),
-        b"mon" => Some(Interval::Months(1)),
-        b"yea" | b"y" => Some(Interval::Months(12)),
+    match s.to_ascii_lowercase().as_str() {
+        "sec" | "s" => Some(Interval::Seconds(1)),
+        "min" | "m" => Some(Interval::Seconds(60)),
+        "hou" | "h" => Some(Interval::Seconds(60 * 60)),
+        "day" | "d" => Some(Interval::Days(1)),
+        "wee" | "w" => Some(Interval::Days(7)),
+        "mon" | "month" => Some(Interval::Months(1)),
+        "yea" | "y" => Some(Interval::Months(12)),
         _ => None,
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -293,19 +293,19 @@ pub fn time_unit(input: &str) -> Option<Interval> {
     let mut buffer = [0; MAX_SIZE];
     buffer[..input.len()].copy_from_slice(input.as_bytes());
     buffer.make_ascii_lowercase();
-    if buffer[0] == 's' as u8 || buffer.starts_with(b"se") {
+    if buffer[0] == b's' || buffer.starts_with(b"se") {
         Some(Interval::Seconds(1))
-    } else if (buffer[0] == 'm' as u8 && input.len() == 1) || buffer.starts_with(b"mi") {
+    } else if (buffer[0] == b'm' && input.len() == 1) || buffer.starts_with(b"mi") {
         Some(Interval::Seconds(60))
-    } else if buffer[0] == 'h' as u8 || buffer.starts_with(b"ho") {
+    } else if buffer[0] == b'h' || buffer.starts_with(b"ho") {
         Some(Interval::Seconds(60 * 60))
-    } else if buffer[0] == 'd' as u8 || buffer.starts_with(b"da") {
+    } else if buffer[0] == b'd' || buffer.starts_with(b"da") {
         Some(Interval::Days(1))
-    } else if buffer[0] == 'w' as u8 || buffer.starts_with(b"we") {
+    } else if buffer[0] == b'w' || buffer.starts_with(b"we") {
         Some(Interval::Days(7))
     } else if buffer.starts_with(b"mo") {
         Some(Interval::Months(1))
-    } else if buffer[0] == 'y' as u8 || buffer.starts_with(b"ye") {
+    } else if buffer[0] == b'y' || buffer.starts_with(b"ye") {
         Some(Interval::Months(12))
     } else {
         None

--- a/src/types.rs
+++ b/src/types.rs
@@ -244,16 +244,31 @@ pub struct DateTimeSpec {
 }
 
 // same as chrono's 'count days from monday' convention
-pub fn week_day(s: &str) -> Option<u8> {
-    match s.to_ascii_lowercase().as_str() {
-        "sun" | "sunday" => Some(6),
-        "mon" | "monday" => Some(0),
-        "tue" | "tuesday" => Some(1),
-        "wed" | "wednesday" => Some(2),
-        "thu" | "thursday" => Some(3),
-        "fri" | "friday" => Some(4),
-        "sat" | "saturday" => Some(5),
-        _ => None,
+pub fn week_day(input: &str) -> Option<u8> {
+    // wednesday is the longest day
+    const MAX_SIZE: usize = 9;
+    if input.len() > MAX_SIZE {
+        return None;
+    }
+    let mut buffer = [0; MAX_SIZE];
+    buffer[..input.len()].copy_from_slice(input.as_bytes());
+    buffer.make_ascii_lowercase();
+    if buffer.starts_with(b"su") {
+        Some(6)
+    } else if buffer.starts_with(b"mo") {
+        Some(0)
+    } else if buffer.starts_with(b"tu") {
+        Some(1)
+    } else if buffer.starts_with(b"we") {
+        Some(2)
+    } else if buffer.starts_with(b"th") {
+        Some(3)
+    } else if buffer.starts_with(b"fr") {
+        Some(4)
+    } else if buffer.starts_with(b"sa") {
+        Some(5)
+    } else {
+        None
     }
 }
 
@@ -280,15 +295,29 @@ pub fn month_name(s: &str) -> Option<u32> {
     }
 }
 
-pub fn time_unit(s: &str) -> Option<Interval> {
-    match s.to_ascii_lowercase().as_str() {
-        "sec" | "s" => Some(Interval::Seconds(1)),
-        "min" | "m" => Some(Interval::Seconds(60)),
-        "hou" | "h" => Some(Interval::Seconds(60 * 60)),
-        "day" | "d" => Some(Interval::Days(1)),
-        "wee" | "w" => Some(Interval::Days(7)),
-        "mon" | "month" => Some(Interval::Months(1)),
-        "yea" | "y" => Some(Interval::Months(12)),
-        _ => None,
+pub fn time_unit(input: &str) -> Option<Interval> {
+    const MAX_SIZE: usize = 7;
+    if input.len() > MAX_SIZE {
+        return None;
+    }
+    let mut buffer = [0; MAX_SIZE];
+    buffer[..input.len()].copy_from_slice(input.as_bytes());
+    buffer.make_ascii_lowercase();
+    if buffer[0] == 's' as u8 || buffer.starts_with(b"se") {
+        Some(Interval::Seconds(1))
+    } else if (buffer[0] == 'm' as u8 && input.len() == 1) || buffer.starts_with(b"mi") {
+        Some(Interval::Seconds(60))
+    } else if buffer[0] == 'h' as u8 || buffer.starts_with(b"ho") {
+        Some(Interval::Seconds(60 * 60))
+    } else if buffer[0] == 'd' as u8 || buffer.starts_with(b"da") {
+        Some(Interval::Days(1))
+    } else if buffer[0] == 'w' as u8 || buffer.starts_with(b"we") {
+        Some(Interval::Days(7))
+    } else if buffer.starts_with(b"mo") {
+        Some(Interval::Months(1))
+    } else if buffer[0] == 'y' as u8 || buffer.starts_with(b"ye") {
+        Some(Interval::Months(12))
+    } else {
+        None
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -244,31 +244,21 @@ pub struct DateTimeSpec {
 }
 
 // same as chrono's 'count days from monday' convention
-pub fn week_day(input: &str) -> Option<u8> {
-    // wednesday is the longest day
-    const MAX_SIZE: usize = 9;
-    if input.len() > MAX_SIZE {
-        return None;
-    }
-    let mut buffer = [0; MAX_SIZE];
-    buffer[..input.len()].copy_from_slice(input.as_bytes());
-    buffer.make_ascii_lowercase();
-    if buffer.starts_with(b"su") {
-        Some(6)
-    } else if buffer.starts_with(b"mo") {
-        Some(0)
-    } else if buffer.starts_with(b"tu") {
-        Some(1)
-    } else if buffer.starts_with(b"we") {
-        Some(2)
-    } else if buffer.starts_with(b"th") {
-        Some(3)
-    } else if buffer.starts_with(b"fr") {
-        Some(4)
-    } else if buffer.starts_with(b"sa") {
-        Some(5)
-    } else {
-        None
+pub fn week_day(s: &str) -> Option<u8> {
+    let mut s = match s.as_bytes() {
+        [a, b, c, ..] => [*a, *b, *c],
+        _ => return None,
+    };
+    s.make_ascii_lowercase();
+    match &s {
+        b"sun" => Some(6),
+        b"mon" => Some(0),
+        b"tue" => Some(1),
+        b"wed" => Some(2),
+        b"thu" => Some(3),
+        b"fri" => Some(4),
+        b"sat" => Some(5),
+        _ => None,
     }
 }
 


### PR DESCRIPTION
So it accepts things like "next second", "last second", "next minute" etc etc up to years which is also what GNU supports end. There's currently an issue with "mon" because this is ambiguous between "monday" or "month". GNU defaults to "monday" but the function just short circuits to "monday" all the time.

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>