### PR TITLE
add: README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # interim
 
+[![Tests](https://github.com/conradludgate/interim/actions/workflows/test.yml/badge.svg)](https://github.com/conradludgate/interim/actions/workflows/test.yml)
+[![docs](https://docs.rs/interim/badge.svg)](https://docs.rs/interim/latest/interim/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Crates.io](https://img.shields.io/crates/v/interim)](https://crates.io/crates/interim)
+
 interim started as a fork, but ended up being a complete over-haul of [chrono-english](https://github.com/stevedonovan/chrono-english).
 
 The API surface is the same, although there's some key differences

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # interim
 
-[![Tests](https://github.com/conradludgate/interim/actions/workflows/test.yml/badge.svg)](https://github.com/conradludgate/interim/actions/workflows/test.yml)
-[![docs](https://docs.rs/interim/badge.svg)](https://docs.rs/interim/latest/interim/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Crates.io](https://img.shields.io/crates/v/interim)](https://crates.io/crates/interim)
+[![Tests](https://img.shields.io/github/actions/workflow/status/conradludgate/interim/test.yml?style=flat-square
+)](https://github.com/conradludgate/interim/actions/workflows/test.yml)
+[![docs](https://img.shields.io/docsrs/interim/latest?style=flat-square)](https://docs.rs/interim/latest/interim/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
+[![Crates.io](https://img.shields.io/crates/v/interim?style=flat-square)](https://crates.io/crates/interim)
 
 interim started as a fork, but ended up being a complete over-haul of [chrono-english](https://github.com/stevedonovan/chrono-english).
 


### PR DESCRIPTION
Adds a few badges and renames the `readme.md` to `README.md`, which seems to be the canonical way of naming that file :D

Just ping me if you want it renamed to lowercase again :) 

The badges can be inspected over here:
https://github.com/Nukesor/interim/tree/badges?tab=readme-ov-file

The `Test` badge doesn't work yet, as it points to the actions on your repo. If you don't want to add the Github Actions, I can also just remove that single badge.