### PR TITLE
Switch to using core::error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ license="MIT"
 rust-version = "1.74.0"
 
 [features]
-default = ["std"]
-std = []
+default = []
 chrono_0_4 = ["dep:chrono"]
 time_0_3 = ["dep:time"]
 jiff_0_1 = ["dep:jiff_0_1"]
@@ -19,13 +18,14 @@ jiff_0_2 = ["dep:jiff_0_2"]
 
 [dependencies]
 time = { version = "0.3.9", default-features = false, optional = true }
-chrono = { version = "0.4.20", default-features = false, optional = true }
+chrono = { git = "https://github.com/benbrittain/chrono.git", branch = "push-lqmnxlrxwsxs", features = ["core-error"], default-features = false, optional = true }
 jiff_0_1 = { package = "jiff", version = "0.1", default-features = false, optional = true }
 jiff_0_2 = { package = "jiff", version = "0.2", default-features = false, optional = true }
-logos = "0.15.0"
+logos = { version = "0.15.0", default-features = false, features = ["export_derive"] }
+
 
 [dev-dependencies]
-chrono = { version = "0.4.20", default-features = false, features = ["clock"] }
+chrono = { git = "https://github.com/benbrittain/chrono.git", branch = "push-lqmnxlrxwsxs", features = ["core-error", "clock"], default-features = false }
 time = { version = "0.3.9", default-features = false, features = ["formatting"] }
 
 jiff_0_1 = { package = "jiff", version = "0.1", features = ["std"] }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -36,7 +36,6 @@ impl fmt::Display for DateError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for DateError {}
+impl core::error::Error for DateError {}
 
 pub type DateResult<T> = Result<T, DateError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@
 //!
 //! ## Features
 //!
-//! * `std`: This crate is `no_std` compatible. Disable the default-features to disable the std-lib features (just error reporting)
 //! * `time_0_3`: This crate is compatible with the [time crate](https://github.com/time-rs/time).
 //! * `chrono_0_4`: This crate is compatible with the [chrono crate](https://github.com/chronotope/chrono).
 //! * `jiff_0_1`: This crate is compatible with the [jiff crate](https://github.com/BurntSushi/jiff).
@@ -95,9 +94,6 @@
 
 #[cfg(test)]
 extern crate alloc;
-
-#[cfg(feature = "std")]
-extern crate std;
 
 /// A collection of traits to abstract over date-time implementations
 pub mod datetime;

--- a/src/types.rs
+++ b/src/types.rs
@@ -55,7 +55,7 @@ impl ByName {
                         extra_week = true;
                     }
                     _ => (),
-                };
+                }
                 let this_day = base_date.weekday() as i64;
                 let that_day = nd as i64;
                 let diff_days = that_day - this_day;


### PR DESCRIPTION
The core::error::Error trait was stabilized in Rust 1.81